### PR TITLE
3. Cycle Drainage Vulnerability Due to Missing Inspect Function

### DIFF
--- a/src/deposits/deposits.mo
+++ b/src/deposits/deposits.mo
@@ -144,6 +144,11 @@ shared(init_msg) actor class Deposits(args: {
     private stable var cachedLedgerBalanceE8s : Nat64 = 0;
     private stable var cachedTokenTotalSupply : Nat64 = 0;
 
+    /// Declining anonymous calls.
+    system func inspect({ caller : Principal }) : Bool {
+        not (Principal.isAnonymous(caller));
+    };
+
     // ===== OWNER FUNCTIONS =====
 
     private let owners = Owners.Owners(args.owners);


### PR DESCRIPTION
Based on the [**ICP documentation**](https://internetcomputer.org/docs/current/motoko/main/writing-motoko/message-inspection).

Adding an `inspect` function to declining anonymous calls:

```
   system func inspect({ caller : Principal }) : Bool {
     not (Principal.isAnonymous(caller));
   }
```