### PR TITLE
9. Unauthorized Access to Neuron Account IDs Due to Ineffective Owner Check

### DIFF
--- a/src/deposits/deposits.mo
+++ b/src/deposits/deposits.mo
@@ -932,7 +932,6 @@ shared(init_msg) actor class Deposits(args: {
     };
 
     public shared(msg) func neuronAccountId(controller: Principal, nonce: Nat64): async Text {
-        owners.require(msg.caller);
         return NNS.accountIdToText(Util.neuronAccountId(args.governance, controller, nonce));
     };
 


### PR DESCRIPTION
Remove the ownership check from the `neuronAccountId()` function to avoid the false security implication.