### PR TITLE
10 Build Failure Due to Duplicate Function Declarations

### DIFF
--- a/src/signing/src/lib.rs
+++ b/src/signing/src/lib.rs
@@ -133,24 +133,6 @@ async fn remove_owner(owner: Principal) {
 }
 
 #[update]
-async fn add_owner(owner: Principal) {
-    require_owner(&api::caller());
-    OWNERS.with(|owners| {
-        let mut o = owners.borrow_mut();
-        o.push(owner);
-    });
-}
-
-#[update]
-async fn remove_owner(owner: Principal) {
-    require_owner(&api::caller());
-    OWNERS.with(|owners| {
-        let mut o = owners.borrow_mut();
-        o.retain(|p| p != &owner);
-    });
-}
-
-#[update]
 async fn get_principal() -> Result<PrincipalReply, String> {
     let public_key = get_public_key().await?;
     Ok(PrincipalReply {


### PR DESCRIPTION
Removing duplicated functions:

```rust
async fn add_owner(owner: Principal);
async fn remove_owner(owner: Principal);
```