### PR TITLE
depositIcpForSubaccount to review

### DIFF
--- a/src/deposits/Withdrawals.mo
+++ b/src/deposits/Withdrawals.mo
@@ -401,6 +401,10 @@ module {
 
         public func completeWithdrawal_account(user: Account, amount: Nat64, to: NNS.AccountIdentifier): Result.Result<WithdrawalCompletion, WithdrawalsError> {
             let now = Time.now();
+            let subaccount = switch (user.subaccount){
+                case null {nullBlob};
+                case (? subaccount ) {subaccount};
+            };
 
             // Figure out which available withdrawals we're disbursing
             var remaining : Nat64 = amount;
@@ -441,7 +445,7 @@ module {
             #ok({
                 transferArgs = {
                     memo : Nat64    = 0;
-                    from_subaccount = null;
+                    from_subaccount = ?Blob.toArray(subaccount);
                     to              = Blob.toArray(to);
                     amount          = { e8s = amount - icpFee };
                     fee             = { e8s = icpFee };


### PR DESCRIPTION
Buenas... no estoy seguro de si este cambio pueda llegar a romper algo, estuve revisando y al parecer no. La idea es la siguiente.

### ✨ Soporte para depósitos individualizados mediante subcuentas en staking

### Descripción:

#### Objetivo:
Permitir que canisters con múltiples usuarios realicen staking de ICP desde subcuentas únicas, facilitando la identificación individual de cada usuario interno.

### Cambios Principales:

#### Nuevas Funciones:

`getDepositAddressForSubaccount(subaccount: Blob)`
Genera una dirección de depósito combinando el Principal del llamante con una subcuenta específica (subaccount), permitiendo a los usuarios externos (o canisters) definir identificadores únicos para sus usuarios internos.

`depositIcpForSubaccount(subaccount: Blob)`
Procesa el depósito asociado a la subcuenta especificada, garantizando que los tokens minteados se asignen correctamente a la cuenta del usuario (caller + subcuenta ) combinada.

#### Modificaciones en doDepositIcpFor:

* Nueva Firma: doDepositIcpFor(user: Principal, _subaccount: ?Blob)
Ahora acepta un parámetro opcional _subaccount para soportar tanto el flujo tradicional (sin subcuenta) como el nuevo flujo (con subcuenta).

* Cálculo de Subcuenta:

Si _subaccount es null, se deriva la subcuenta directamente del Principal del usuario (comportamiento original).

Si _subaccount está definido, se combina con el Principal del usuario mediante una operación de suma modular byte a byte (ver accountToSubaccount).

#### Detalles Técnicos:

Lógica de Combinación de Subcuentas:
La función accountToSubaccount fusiona la subcuenta base (derivada del Principal del usuario) con la subcuenta proporcionada por ese usuario, generando un identificador único para cada subcuenta que ese mismo usuario especifique en futuras interacciones.

#### Riesgo de Colisión:
La suma modular utilizada ((a1[i] + a2[i]) % 256) tiene una probabilidad extremadamente baja de colisión si las subcuentas proporcionadas (a2) son generadas de manera única (e.g., mediante UUIDs o contadores controlados por el canister externo).

### Notas Adicionales:

#### Retrocompatibilidad:
Las modificaciones en las funciones existentes (depositIcp, depositIcpFor) no implican cambios en su firma ni en su comportamiento, ya que estos cambios están relacionados a la llamada interna a la función doDepositIcpFor la cual, debido a la modificación introducida, se invoca ahora con el parámetro  _subaccount = null, preservando el comportamiento original.

Verificación de Seguridad:
Se asegura que los tokens minteados se asignen a cuentas cuyo owner será el principal del caller, e identificables individualmente por la subaccount especificada en el nuevo parámetro y derivada externamente del principal del usuario o de cualquier otro valor que el caller quiera establecer para identificarla de otras cuentas de su misma propiedad